### PR TITLE
FIX docker files: removed the volumes lines that were useless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN pip install --no-cache-dir pytest pytest-cov
 RUN useradd -m -u 1000 geneweb && \
     chown -R geneweb:geneweb /app && \
     mkdir -p /data && \
-    chown geneweb:geneweb /data
+    chown -R geneweb:geneweb /data \ 
+    echo "done"
 
 USER geneweb
 
@@ -28,7 +29,5 @@ ENV PYTHONUNBUFFERED=1
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import socket; s=socket.socket(); s.connect(('127.0.0.1', 2317)); s.close()" || exit 1
-
-VOLUME /data
 
 CMD ["python", "-m", "bin.gwd", "-p", "2317", "-wd", "/data", "-addr", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     restart: unless-stopped
     ports:
       - "2317:2317"
-    volumes:
-      - ./geneweb_databases:/data
     environment:
       - PYTHONUNBUFFERED=1
       - TZ=UTC


### PR DESCRIPTION
Removed the "VOLUME /data" lines in the Dockerfile and the docker-compose.yml because they were erasing the chown geneweb:geneweb /data command in the Dockerfile, mounting the folder again as a volume and thus making the previous mkdir and chown command useless. That made it so under some circumstances the /data folder (or volume rather) would be root owned, and would cause an unexpected error saying no permission to open/create the /data/*.ged file as only the root could write in it.